### PR TITLE
Initial docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+Dockerfile
+.dockerignore
+node_modules
+npm-debug.log
+README.md
+.next
+.git
+.env
+db.sqlite3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,8 @@
     },
     "files.associations": {
         "*.css": "tailwindcss"
+    },
+    "[dockerfile]": {
+        "editor.defaultFormatter": "ms-azuretools.vscode-docker"
     }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+FROM node:18-alpine AS base
+
+# Install dependencies only when needed
+FROM base AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN \
+    if [ -f package-lock.json ]; then npm ci; \
+    else echo "Lockfile not found." && exit 1; \
+    fi
+
+
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Disable Next.js telemetry during build
+# Learn more here: https://nextjs.org/telemetry
+ENV NEXT_TELEMETRY_DISABLED 1
+
+# Build app using next.js experimental compile
+RUN \
+    if [ -f package-lock.json ]; then npm run compile; \
+    else echo "Lockfile not found." && exit 1; \
+    fi
+
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
+
+RUN apk add --no-cache su-exec
+
+ENV NODE_ENV production
+
+# Disable Next.js telemetry during runtime
+ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+# Enable if using the public folder
+# COPY --from=builder /app/public ./public
+
+# Set the correct permission for prerender cache
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+# Copy dbmate because nextjs doesn't think we need it by default
+COPY --from=deps /app/node_modules/dbmate ./node_modules/dbmate
+COPY --from=deps /app/node_modules/@dbmate ./node_modules/@dbmate
+
+COPY --from=builder /app/docker/docker-entrypoint.sh /sbin/docker-entrypoint.sh
+RUN chmod +x /sbin/docker-entrypoint.sh
+
+EXPOSE 3000
+
+ENV PORT 3000
+ENV HOSTNAME "0.0.0.0"
+ENV DATABASE_URL "sqlite3:/data/db.sqlite3"
+ENV DBMATE_MIGRATIONS_DIR "/app/src/db/migrations"
+
+VOLUME ["/data"]
+
+ENTRYPOINT ["/sbin/docker-entrypoint.sh"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+migrations() {
+    echo "Applying database migrations..."
+
+    /app/node_modules/@dbmate/linux-x64/bin/dbmate up
+}
+
+ensure_permissions() {
+    echo "Applying correct permissions..."
+
+    chown -R nextjs:nodejs /data
+}
+
+echo "DocuDump docker container starting..."
+
+migrations
+
+ensure_permissions
+
+su-exec nextjs node /app/server.js

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    output: "standalone",
+};
 
 export default nextConfig;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -17,11 +17,23 @@ let migrationFiles = readdirSync(migrationsDir).filter((entry) =>
     entry.endsWith(".sql"),
 );
 
-let databasePath = path.join(process.cwd(), "db.sqlite3");
+// Sanity check that at least one migration file exists
+if (migrationFiles.length < 1) {
+    throw new Error("No migration files found. Ensure the cwd is properly set");
+}
+
+let databasePath = process.env.DATABASE_URL?.split("sqlite3:")[1];
+if (typeof databasePath !== "string") {
+    databasePath = path.join(process.cwd(), "db.sqlite3");
+}
+
 if (!existsSync(databasePath)) {
     throw new Error("Database not instantiated");
 }
-const db = new Database(databasePath);
+
+const db = new Database(databasePath, {
+    fileMustExist: true,
+});
 
 // Check that all migrations have been applied (sanity check upon first db use)
 const stmt = db.prepare(`


### PR DESCRIPTION
Adds preliminary docker support. Soon, we will add automatic building and publishing to GHCR via GHA.

In the meantime, a dev docker image can be built with `docker build . -t localhost/docudump-dev` and run with `docker run --rm -itp 8080:3000 -v "./dockerdata:/data" localhost/docudump-dev`, given that you have created a local `dockerdata` folder to persist data between runs (currently just the database). You can also omit the `-v "./dockerdata:/data"` flag and the container will run with amnesia. 