### PR TITLE
Rename GHA docker build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             - run: ./lint.sh
 
     build-docker-image:
-        name: Build Docker image for ${{ github.ref_name }}
+        name: Build and push Docker image
         runs-on: ubuntu-22.04
         if: github.event_name == 'push'
         concurrency:


### PR DESCRIPTION
Gets rid of using the ref name