### PR TITLE
Dockerfile: explicitly copy src/db/migrations to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,11 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 # Copy dbmate because nextjs doesn't think we need it by default
-COPY --from=deps /app/node_modules/dbmate ./node_modules/dbmate
-COPY --from=deps /app/node_modules/@dbmate ./node_modules/@dbmate
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/dbmate ./node_modules/dbmate
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/@dbmate ./node_modules/@dbmate
+COPY --from=builder --chown=nextjs:nodejs /app/src/db/migrations /app/src/db/migrations
 
-COPY --from=builder /app/docker/docker-entrypoint.sh /sbin/docker-entrypoint.sh
+COPY --from=builder --chown=nextjs:nodejs /app/docker/docker-entrypoint.sh /sbin/docker-entrypoint.sh
 RUN chmod +x /sbin/docker-entrypoint.sh
 
 EXPOSE 3000


### PR DESCRIPTION
The next.js build step doesn't copy it all the time but we super need it