### PR TITLE
Add monaco editor for line numbers and syntax highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
             "name": "docudump",
             "version": "0.1.0",
             "dependencies": {
+                "@monaco-editor/react": "^4.6.0",
                 "better-sqlite3": "^9.3.0",
                 "dotenv": "^16.4.1",
+                "monaco-editor": "^0.46.0",
                 "next": "14.1.0",
                 "react": "^18",
                 "react-dom": "^18",
@@ -337,6 +339,30 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@monaco-editor/loader": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+            "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+            "dependencies": {
+                "state-local": "^1.0.6"
+            },
+            "peerDependencies": {
+                "monaco-editor": ">= 0.21.0 < 1"
+            }
+        },
+        "node_modules/@monaco-editor/react": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+            "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+            "dependencies": {
+                "@monaco-editor/loader": "^1.4.0"
+            },
+            "peerDependencies": {
+                "monaco-editor": ">= 0.25.0 < 1",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/@next/env": {
@@ -3341,6 +3367,11 @@
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
         },
+        "node_modules/monaco-editor": {
+            "version": "0.46.0",
+            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.46.0.tgz",
+            "integrity": "sha512-ADwtLIIww+9FKybWscd7OCfm9odsFYHImBRI1v9AviGce55QY8raT+9ihH8jX/E/e6QVSGM+pKj4jSUSRmALNQ=="
+        },
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4575,6 +4606,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/state-local": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+            "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
         },
         "node_modules/streamsearch": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
         "compile": "next experimental-compile"
     },
     "dependencies": {
+        "@monaco-editor/react": "^4.6.0",
         "better-sqlite3": "^9.3.0",
         "dotenv": "^16.4.1",
+        "monaco-editor": "^0.46.0",
         "next": "14.1.0",
         "react": "^18",
         "react-dom": "^18",

--- a/src/app/(site)/home/pastetab.tsx
+++ b/src/app/(site)/home/pastetab.tsx
@@ -1,38 +1,62 @@
 "use client";
 
 import React, { useState } from "react";
+import Editor from "@monaco-editor/react";
 import Settings from "./settings";
+import { LanguageKey } from "@/app/types";
+import { languageOptions } from "@/app/constants";
 
 function PasteTab() {
-    const [pasteText, setPasteText] = useState("");
-    const [syntaxHighlight, setSyntaxHighlight] = useState("None");
+    const [currentText, setCurrentText] = useState(""); // Holds the current text
+    const [language, setLanguage] = useState<LanguageKey>("plaintext");
 
-    // TODO: #14 - Add syntax highlighting and line numbers in textarea
+    const handleLanguageChange = (
+        event: React.ChangeEvent<HTMLSelectElement>,
+    ) => {
+        const newLanguage = event.target.value as LanguageKey;
+        setLanguage(newLanguage);
+        setCurrentText("");
+    };
 
     return (
         <div className="space-y-4">
             <div className="text-right">
                 <select
-                    value={syntaxHighlight}
-                    onChange={(e) => setSyntaxHighlight(e.target.value)}
+                    value={language}
+                    onChange={handleLanguageChange}
                     className="rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm outline-none"
                 >
-                    <option value="Python">Python</option>
-                    <option value="Java">Java</option>
+                    {Object.entries(languageOptions).map(([key, display]) => (
+                        <option key={key} value={key}>
+                            {display}
+                        </option>
+                    ))}
                 </select>
             </div>
 
             <div>
-                <textarea
-                    id="message"
-                    placeholder="Paste your content here..."
-                    rows={12}
-                    maxLength={1000}
-                    onChange={(e) => {
-                        setPasteText(e.target.value);
+                <Editor
+                    height="50vh"
+                    defaultLanguage="plaintext"
+                    language={language}
+                    value={currentText} // Use the current text
+                    onChange={(value) => {
+                        // Check if the incoming value is not undefined before updating the state
+                        if (value !== undefined) {
+                            setCurrentText(value);
+                        }
                     }}
-                    className="w-full rounded-lg border border-gray-300 bg-gray-50 bg-transparent p-2.5 pl-2 transition-colors duration-200 focus:border-blue-500 focus:outline-none focus:ring-blue-500"
-                ></textarea>
+                    theme="vs-light"
+                    options={{
+                        lineNumbers: "on",
+                        scrollBeyondLastLine: false,
+                        readOnly: false,
+                        minimap: {
+                            enabled: false,
+                        },
+                    }}
+                    className="w-full rounded-sm border bg-gray-50 transition-colors duration-200"
+                />
             </div>
             <Settings />
 

--- a/src/app/(site)/home/pastetab.tsx
+++ b/src/app/(site)/home/pastetab.tsx
@@ -15,7 +15,6 @@ function PasteTab() {
     ) => {
         const newLanguage = event.target.value as LanguageKey;
         setLanguage(newLanguage);
-        setCurrentText("");
     };
 
     return (

--- a/src/app/(site)/home/pastetab.tsx
+++ b/src/app/(site)/home/pastetab.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from "react";
 import Editor from "@monaco-editor/react";
-import Settings from "./settings";
+import Settings from "@/app/(site)/home/settings";
 import { LanguageKey } from "@/app/types";
 import { languageOptions } from "@/app/constants";
 

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -1,4 +1,4 @@
-import { LanguageKey } from "./types";
+import { LanguageKey } from "@/app/types";
 
 export const languageOptions: Record<LanguageKey, string> = {
     plaintext: "Plain Text",

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -1,0 +1,11 @@
+import { LanguageKey } from "./types";
+
+export const languageOptions: Record<LanguageKey, string> = {
+    plaintext: "Plain Text",
+    python: "Python",
+    java: "Java",
+    javascript: "JavaScript",
+    typescript: "TypeScript",
+    csharp: "C#",
+    c: "C",
+};

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,0 +1,8 @@
+export type LanguageKey =
+    | "plaintext"
+    | "python"
+    | "java"
+    | "javascript"
+    | "typescript"
+    | "csharp"
+    | "c";


### PR DESCRIPTION
Added the Monaco editor (code editor that power VSCode) to support line numbers and syntax highlighting for a variety of different languages which the user can choose from. Note that it defaults to plain text.

<img width="800" alt="Screenshot 2024-03-03 124412" src="https://github.com/DocuDump/DocuDump/assets/92958582/bcf29d03-817c-4358-85b1-784485b0ad19">
