### PR TITLE
URL display button with copy abilities

### DIFF
--- a/src/app/(site)/home/logos/copytoclipboard.tsx
+++ b/src/app/(site)/home/logos/copytoclipboard.tsx
@@ -1,0 +1,15 @@
+function CopyToClipboard() {
+    return (
+        <svg
+            className="inline h-4 fill-current pr-4"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+        >
+            <path d="M8 2a1 1 0 000 2h2a1 1 0 100-2H8z"></path>
+            <path d="M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z"></path>
+        </svg>
+    );
+}
+
+export default CopyToClipboard;

--- a/src/app/(site)/home/urltab.tsx
+++ b/src/app/(site)/home/urltab.tsx
@@ -1,10 +1,20 @@
 import Settings from "@/app/(site)/home/settings";
 import { shortenURL } from "@/app/actions/shortenurl";
+import { useState } from "react";
 
 import { useFormState } from "react-dom";
 
 export default function URLTab() {
+    const currentDomain = window.location.origin;
     const [shortcode, formAction] = useFormState(shortenURL, null);
+    const [isCopied, setIsCopied] = useState(false);
+
+    const copyToClipboard = (text: string) => {
+        navigator.clipboard.writeText(text);
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), 3000); // Reset copy status after 3 seconds so it disappears
+    };
+
     return (
         <form action={formAction}>
             <div className="mb-10">
@@ -55,14 +65,37 @@ export default function URLTab() {
                 Shorten
             </button>
             {shortcode && (
-                <p
-                    className={`mt-6 text-3xl ${shortcode.success ? "" : "text-red-500"}`}
-                >
-                    {shortcode.success
-                        ? `Generated Code: ${shortcode.message}`
-                        : shortcode.message}
-                </p>
+                <>
+                    {shortcode.success ? (
+                        <div>
+                            <button
+                                onClick={() =>
+                                    copyToClipboard(
+                                        `${currentDomain}/${shortcode.message}`,
+                                    )
+                                }
+                                className="test-sm mt-5 h-10 rounded-lg border border-blue-500 bg-transparent px-5 py-2.5 font-medium text-blue-700 hover:border-transparent hover:bg-blue-500 hover:text-white focus:outline-none"
+                            >
+                                <svg
+                                    className="inline h-4 fill-current pr-4"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 20 20"
+                                    fill="currentColor"
+                                >
+                                    <path d="M8 2a1 1 0 000 2h2a1 1 0 100-2H8z"></path>
+                                    <path d="M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z"></path>
+                                </svg>
+                                <span>{`${currentDomain}/${shortcode.message}`}</span>
+                            </button>
+                        </div>
+                    ) : (
+                        <p className="mt-6 text-3xl text-red-500">
+                            {shortcode.message}
+                        </p>
+                    )}
+                </>
             )}
+            {isCopied && <span className="text-green-500">Copied!</span>}
         </form>
     );
 }

--- a/src/app/(site)/home/urltab.tsx
+++ b/src/app/(site)/home/urltab.tsx
@@ -1,6 +1,7 @@
 import Settings from "@/app/(site)/home/settings";
 import { shortenURL } from "@/app/actions/shortenurl";
 import { useState } from "react";
+import CopyToClipboard from "@/app/(site)/home/logos/copytoclipboard";
 
 import { useFormState } from "react-dom";
 
@@ -76,15 +77,7 @@ export default function URLTab() {
                                 }
                                 className="test-sm mt-5 h-10 rounded-lg border border-blue-500 bg-transparent px-5 py-2.5 font-medium text-blue-700 hover:border-transparent hover:bg-blue-500 hover:text-white focus:outline-none"
                             >
-                                <svg
-                                    className="inline h-4 fill-current pr-4"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 20 20"
-                                    fill="currentColor"
-                                >
-                                    <path d="M8 2a1 1 0 000 2h2a1 1 0 100-2H8z"></path>
-                                    <path d="M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z"></path>
-                                </svg>
+                                <CopyToClipboard />
                                 <span>{`${currentDomain}/${shortcode.message}`}</span>
                             </button>
                         </div>


### PR DESCRIPTION
Made a display button for the shortened URL. When clicked, it will copy to clickboard and user can paste wherever they would like.

I found some logic to get the current domain by using window.location.origin. Don't think this is how we will want to do this in the end but it works for now. In the screenshots I was running on localhost port 3000 so it successfully gets that domain.

I found the icon at this site: https://www.tailwindtoolbox.com/icons

Without hovering over button:
<img width="1381" alt="Screenshot 2024-03-07 at 7 20 20 PM" src="https://github.com/DocuDump/DocuDump/assets/121988118/2da7a898-b3fd-4bbc-9de8-fa4300f08a98">

On Click while hovering:
<img width="1099" alt="Screenshot 2024-03-07 at 7 22 35 PM" src="https://github.com/DocuDump/DocuDump/assets/121988118/47a0ca38-f55d-438c-a384-b3fd31579c0b">

FYI, The copied button goes away after 3 seconds 