### PR TITLE
File Preview

### DIFF
--- a/src/app/(site)/[slug]/filepreview.tsx
+++ b/src/app/(site)/[slug]/filepreview.tsx
@@ -1,61 +1,49 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { FileEntry } from "@/db";
+import Link from "next/link";
 
-interface FilePreviewProps {
-    file: FileEntry;
-}
-
-const FilePreview: React.FC<FilePreviewProps> = ({ file }) => {
+const FilePreview: React.FC<{ file: FileEntry }> = ({ file }) => {
     const { slug } = useParams();
 
-    console.log(file.mime_type);
-    switch (file.mime_type.split("/")[0]) {
-        case "text":
-        case "application":
-            return (
-                <div>
-                    <h2>{file.file_name}</h2>
+    return (
+        <>
+            <div className="mx-auto flex max-w-[90%] flex-col items-center justify-center">
+                <h2 className="my-4 text-2xl font-bold">Slug: {slug}</h2>
+                {file.mime_type.startsWith("text") ||
+                file.mime_type.startsWith("application") ? (
                     <iframe
                         src={`/raw/${slug}`}
-                        width="75%"
+                        className="w-full max-w-[800px] border-2"
                         height="500"
-                        frameBorder="0"
                         title={file.file_name}
                     />
-                </div>
-            );
-        case "image":
-            return (
-                <div>
-                    <h2>{file.file_name}</h2>
+                ) : file.mime_type.startsWith("image") ? (
                     <img
                         src={`/raw/${slug}`}
                         alt={file.file_name}
-                        width="75%"
+                        className="w-full max-w-[800px]"
                     />
-                </div>
-            );
-        case "video":
-            return (
-                <div>
-                    <h2>{file.file_name}</h2>
-                    <video controls width="100%">
+                ) : file.mime_type.startsWith("video") ? (
+                    <video controls className="w-full max-w-[800px]">
                         <source src={`/raw/${slug}`} type={file.mime_type} />
                         Your browser does not support the video tag.
                     </video>
-                </div>
-            );
-        default:
-            return (
-                <div>
-                    <h2>{file.file_name}</h2>
+                ) : (
                     <p>Unable to preview this file type.</p>
-                </div>
-            );
-    }
+                )}
+            </div>
+            <div className="mx-auto flex max-w-[90%] flex-col items-center justify-center pt-14">
+                <Link
+                    href={`/raw/${slug}`}
+                    className="rounded bg-blue-500 px-1.5 py-4 text-sm font-bold text-white hover:bg-blue-700 hover:text-gray-200 md:px-4 md:py-2 md:text-lg"
+                >
+                    Download {file.file_name}
+                </Link>
+            </div>
+        </>
+    );
 };
 
 export default FilePreview;

--- a/src/app/(site)/[slug]/filepreview.tsx
+++ b/src/app/(site)/[slug]/filepreview.tsx
@@ -1,0 +1,61 @@
+("use client");
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { FileEntry } from "@/db";
+
+interface FilePreviewProps {
+    file: FileEntry;
+}
+
+const FilePreview: React.FC<FilePreviewProps> = ({ file }) => {
+    const { slug } = useParams();
+
+    console.log(file.mime_type);
+    switch (file.mime_type.split("/")[0]) {
+        case "text":
+        case "application":
+            return (
+                <div>
+                    <h2>{file.file_name}</h2>
+                    <iframe
+                        src={`/raw/${slug}`}
+                        width="75%"
+                        height="500"
+                        frameBorder="0"
+                        title={file.file_name}
+                    />
+                </div>
+            );
+        case "image":
+            return (
+                <div>
+                    <h2>{file.file_name}</h2>
+                    <img
+                        src={`/raw/${slug}`}
+                        alt={file.file_name}
+                        width="75%"
+                    />
+                </div>
+            );
+        case "video":
+            return (
+                <div>
+                    <h2>{file.file_name}</h2>
+                    <video controls width="100%">
+                        <source src={`/raw/${slug}`} type={file.mime_type} />
+                        Your browser does not support the video tag.
+                    </video>
+                </div>
+            );
+        default:
+            return (
+                <div>
+                    <h2>{file.file_name}</h2>
+                    <p>Unable to preview this file type.</p>
+                </div>
+            );
+    }
+};
+
+export default FilePreview;

--- a/src/app/(site)/[slug]/filepreview.tsx
+++ b/src/app/(site)/[slug]/filepreview.tsx
@@ -1,4 +1,4 @@
-("use client");
+"use client";
 
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";

--- a/src/app/(site)/[slug]/page.tsx
+++ b/src/app/(site)/[slug]/page.tsx
@@ -12,12 +12,7 @@ export default async function ShortcodeHandler({
     if (result.redirect) {
         redirect(result.redirect.redirect_url);
     } else if (result.file) {
-        return (
-            <FilePreview
-                file={result.file}
-                // Pass any other necessary props to the FilePreview component
-            />
-        );
+        return <FilePreview file={result.file} />;
     } else {
         return notFound();
     }

--- a/src/app/(site)/[slug]/page.tsx
+++ b/src/app/(site)/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound, redirect } from "next/navigation";
 import { queryShortcode } from "@/db";
+import FilePreview from "@/app/(site)/[slug]/filepreview";
 
 export default async function ShortcodeHandler({
     params,
@@ -11,8 +12,13 @@ export default async function ShortcodeHandler({
     if (result.redirect) {
         redirect(result.redirect.redirect_url);
     } else if (result.file) {
-        // TODO: handle result.file
+        return (
+            <FilePreview
+                file={result.file}
+                // Pass any other necessary props to the FilePreview component
+            />
+        );
     } else {
-        notFound();
+        return notFound();
     }
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -95,7 +95,7 @@ interface Redirect {
     redirect_url: string;
 }
 
-interface FileEntry {
+export interface FileEntry {
     id: number;
     sha256: string;
     file_name: string;


### PR DESCRIPTION
Added functionality for preview of the raw file within our website.
When the user clicks the download button, it takes them to the link of the raw URL (similar to yld.me's functionality)

Example of pdf:
![image](https://github.com/DocuDump/DocuDump/assets/92958582/3e17c820-3cfa-4e1e-8e25-5a033cb6bca4)

Example of txt:
![image](https://github.com/DocuDump/DocuDump/assets/92958582/7afd5cf7-f147-47b9-abbb-f0961756f6ba)


Example of photo:
![image](https://github.com/DocuDump/DocuDump/assets/92958582/c62055ed-1d88-4420-b33d-fdafaf1b1c5b)

