### PR TITLE
Mobile Responsiveness

### DIFF
--- a/src/app/(site)/home/page.tsx
+++ b/src/app/(site)/home/page.tsx
@@ -25,7 +25,7 @@ function Home() {
                                         e.preventDefault(); // Prevent the link from navigating
                                         changeTab(tab);
                                     }}
-                                    className={`inline-block rounded-t-lg border-b-2 px-0 py-2 text-lg sm:text-xl ${activeTab === tab ? "border-blue-600 text-blue-600 dark:border-blue-500 dark:text-blue-500" : "border-transparent text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-100"}`}
+                                    className={`inline-block rounded-t-lg border-b-2 px-0 py-2 text-lg sm:p-4 sm:text-xl ${activeTab === tab ? "border-blue-600 text-blue-600 dark:border-blue-500 dark:text-blue-500" : "border-transparent text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-100"}`}
                                 >
                                     {tab}
                                 </a>

--- a/src/app/(site)/home/settings.tsx
+++ b/src/app/(site)/home/settings.tsx
@@ -64,7 +64,7 @@ function Settings() {
                         </select>
                     </div>
 
-                    <div className="mb-8">
+                    <div>
                         <div className="mb-1 ml-2 flex gap-2 text-sm font-medium text-gray-700">
                             Paste Status
                         </div>

--- a/src/app/(site)/home/urltab.tsx
+++ b/src/app/(site)/home/urltab.tsx
@@ -82,7 +82,7 @@ export default function URLTab() {
             <Settings />
             <button
                 type="submit"
-                className="h-10 w-full rounded-lg bg-blue-500 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 sm:w-auto"
+                className="mt-8 h-10 w-full rounded-lg bg-blue-500 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 sm:w-auto"
             >
                 Shorten
             </button>

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -10,7 +10,9 @@ export default function SiteLayout({
         <section>
             <div className={`flex min-h-screen flex-col`}>
                 <Navbar />
-                <main className="mb-20 flex-grow">{children}</main>
+                <main className="mb-20 flex-grow overflow-auto">
+                    {children}
+                </main>
                 <Footer />
             </div>
         </section>


### PR DESCRIPTION
Fixed some issues with using the application on mobile devices (closes #53).

The "custom settings" now automatically go to a 1-column layout that now doesn't have any overlap issues:

<img src="https://github.com/DocuDump/DocuDump/assets/69359897/adaef427-b028-4ce0-9ecf-23a3582a4ccc" height="600">

The "File", "Paste", "URL" buttons now shrink to fit one row when device is small:

<img src="https://github.com/DocuDump/DocuDump/assets/69359897/83f81083-efc0-4b91-a774-274f0cc61e80" height="600">

The "custom URL" now has an alternate input box when on mobile, to make it fit to screen:

<img src="https://github.com/DocuDump/DocuDump/assets/69359897/971fad55-8fda-4e20-8625-3a111110a4ce" height="600">

The "pastes" menu now makes overflow scroll, so the header no longer shows whitespace:

<img src="https://github.com/DocuDump/DocuDump/assets/69359897/b0d48e4e-8f24-447a-81d4-6d916b5ec872" height="600">

Let me know what you think of this, I am happy to change anything if we need.